### PR TITLE
fix: Fix order price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -8,11 +8,12 @@ from .base import BaseController
 
 class OrderController(BaseController):
     manager = OrderManager
-    __required_info = ('client_name', 'client_dni', 'client_address', 'client_phone', 'size_id')
+    __required_info = ('client_name', 'client_dni','client_address', 'client_phone', 'size_id')
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        ingredients_price = sum(ingredient.price for ingredient in ingredients)
+        price = ingredients_price + size_price
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
The order price now is included in the sum of the ingredients plus the pizza size

Files Modified: 
I just modify the python-pizza-planet\app\controllers\order.py file to add the pizza size sum.